### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/duoslow/2e47cd40-813e-4ebb-ac72-0cc0e7f5a5d9/20225c50-a275-4cf8-914f-d85f24b5f075/_apis/work/boardbadge/64373e22-ee7a-49a2-be2d-934009b29264)](https://dev.azure.com/duoslow/2e47cd40-813e-4ebb-ac72-0cc0e7f5a5d9/_boards/board/t/20225c50-a275-4cf8-914f-d85f24b5f075/Microsoft.RequirementCategory)
 # Zerotier KDE Widget  
 ## This Widget Shows Zerotier Network Members
 ### I can't continue developing because I don't have time


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/duoslow/2e47cd40-813e-4ebb-ac72-0cc0e7f5a5d9/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.